### PR TITLE
Make parse pool size configurable at runtime

### DIFF
--- a/DEBUGGING.MD
+++ b/DEBUGGING.MD
@@ -1,4 +1,10 @@
 # Debug Flags
 - `TMX_RX_DEBUG`: Debug message on recieving
 - `TMX_TX_DEBUG`: Debug message on transmission
-- `TMX_HW_DEBUG`: Set poolsize to 1.
+
+## Deprecated
+Deprecated debug flags and there replacements:
+
+|      Flag      | Description        | Replacement                                                           |
+| :------------: | :----------------- | :-------------------------------------------------------------------- |
+| `TMX_HW_DEBUG` | Set poolsize to 1. | Intialize the `tmx_cpp::TMX` object with `parse_pool_size` equal to 1 |

--- a/include/tmx_cpp/tmx.hpp
+++ b/include/tmx_cpp/tmx.hpp
@@ -67,7 +67,7 @@ public:
   // Sensors sensors;
 
 public:
-  TMX(std::function<void()> stop_func, std::string port = "/dev/ttyACM0");
+  TMX(std::function<void()> stop_func, std::string port = "/dev/ttyACM0", size_t parse_pool_size = std::thread::hardware_concurrency());
   ~TMX();
   enum PIN_MODES : uint8_t {
     DIGITAL_INPUT = 0,

--- a/include/tmx_cpp/tmx.hpp
+++ b/include/tmx_cpp/tmx.hpp
@@ -67,7 +67,8 @@ public:
   // Sensors sensors;
 
 public:
-  TMX(std::function<void()> stop_func, std::string port = "/dev/ttyACM0", size_t parse_pool_size = std::thread::hardware_concurrency());
+  TMX(std::function<void()> stop_func, std::string port = "/dev/ttyACM0",
+      size_t parse_pool_size = std::thread::hardware_concurrency());
   ~TMX();
   enum PIN_MODES : uint8_t {
     DIGITAL_INPUT = 0,


### PR DESCRIPTION
Patch to make the size of `parsePool` configurable at runtime instead of determining it at compile time.

This allows for more flexibility and prevents that the number of threads is determined by the number of cores of the build farm/GitHub Action runner